### PR TITLE
支持使用 Swift Module 之后可以使用其他类的功能

### DIFF
--- a/LDNetDiagnoService.podspec
+++ b/LDNetDiagnoService.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.platform = :ios
   s.requires_arc = true
   s.ios.deployment_target = '7.0'
-  s.ios.public_header_files = 'LDNetDiagnoService/LDNetDiagnoService.h'
+  s.ios.public_header_files = 'LDNetDiagnoService/*.h'
   s.ios.source_files = 'LDNetDiagnoService/*.{h,m}'
   s.ios.framework = 'CoreTelephony'
   s.ios.library = 'resolv'


### PR DESCRIPTION
嗨，当我在 Swift 项目中使用 Cocoapods 引入该库的时候发现只有 LDNetDiagnoService 可以用。现在希望通过修改 Podspec 文件之后可以支持在 Swift 中使用其他类的功能。